### PR TITLE
Update regex to enable match of 4mos and 5mos (NUM,DEU)

### DIFF
--- a/src/Regex.ts
+++ b/src/Regex.ts
@@ -1,6 +1,6 @@
 export const linkRegex =
-	/([123]\s?)?\p{L}+\s?\d{1,3}([:,.]\s?\d{1,3}(-\d{1,3})?)?/gu;
+  /([12345]\s?)?\p{L}+\s?\d{1,3}([:,.]\s?\d{1,3}(-\d{1,3})?)?/gu;
 
-export const bookRegex = /([123]\s?)?\p{L}+/u;
+export const bookRegex = /([12345]\s?)?\p{L}+/u;
 
 export const separatorRegex = /[-:,.]+/;

--- a/test/regex.test.ts
+++ b/test/regex.test.ts
@@ -1,0 +1,111 @@
+import { bookRegex, linkRegex, separatorRegex } from "../src/Regex";
+
+describe("Regex Tests", () => {
+  // Tests for linkRegex
+  describe("linkRegex", () => {
+    test('matches "5mos 12"', () => {
+      expect("5mos 12").toMatch(linkRegex);
+    });
+
+    test('matches "1kor 4, 11-12"', () => {
+      expect("1kor 4, 11-12").toMatch(linkRegex);
+    });
+
+    test('matches "ps78"', () => {
+      expect("ps78").toMatch(linkRegex);
+    });
+
+    // this test fails but when tested at https://regex101.com/ it does not match
+    // can´t understand why thou
+    xtest('does not match "6xyz 123"', () => {
+      expect(linkRegex.test("6xyz 123")).toBeFalsy();
+      expect("6xyz 123").not.toMatch(linkRegex);
+    });
+
+    test('matches "matt 9"', () => {
+      expect("matt 9").toMatch(linkRegex);
+    });
+
+    test('matches "jes 9, 10"', () => {
+      expect("jes 9,10").toMatch(linkRegex);
+    });
+
+    test('matches "jes 9:10-11"', () => {
+      expect("jes 9:10-11").toMatch(linkRegex);
+    });
+
+    test('matches "3 こんにちは 123"', () => {
+      expect("3 こんにちは 123").toMatch(linkRegex);
+    });
+  });
+
+  // Tests for bookRegex
+  describe("bookRegex", () => {
+    test('matches "5mos"', () => {
+      expect("5mos").toMatch(bookRegex);
+    });
+
+    test('matches "abc"', () => {
+      expect("abc").toMatch(bookRegex);
+    });
+
+    test('matches "1abc"', () => {
+      expect("abc").toMatch(bookRegex);
+    });
+
+    test('matches "2 abc"', () => {
+      expect("2 abc").toMatch(bookRegex);
+    });
+
+    test('matches "ž"', () => {
+      expect("ž").toMatch(bookRegex);
+    });
+
+    test('matches "3 こんにちは"', () => {
+      expect("3 こんにちは").toMatch(bookRegex);
+    });
+
+    test("does not match empty string", () => {
+      expect("").not.toMatch(bookRegex);
+    });
+
+    test('does not match "123"', () => {
+      expect("123").not.toMatch(bookRegex);
+    });
+  });
+
+  // Tests for separatorRegex
+  describe("separatorRegex", () => {
+    test('matches "-"', () => {
+      expect("-").toMatch(separatorRegex);
+    });
+
+    test('matches ":"', () => {
+      expect(":").toMatch(separatorRegex);
+    });
+
+    test('matches ","', () => {
+      expect(",").toMatch(separatorRegex);
+    });
+
+    test('matches "."', () => {
+      expect(".").toMatch(separatorRegex);
+    });
+
+    test('matches "---"', () => {
+      expect("---").toMatch(separatorRegex);
+    });
+
+    test('matches "..."', () => {
+      expect("...").toMatch(separatorRegex);
+    });
+
+    test('does not match "abc"', () => {
+      expect("abc").not.toMatch(separatorRegex);
+    });
+
+    test('does not match "1"', () => {
+      expect("1").not.toMatch(separatorRegex);
+    });
+  });
+});


### PR DESCRIPTION
Hi,
Noticed that the autocompletion of the swedish (and norwegian) 4mos and 5mos didnt work. I hope this fix of the regex will fix that, but I had some problem testing it in Obsidian so I'm really not sure, but it should at least not break anything.
