### PR TITLE
Fixed extra k in "krønikke" to "krønike"

### DIFF
--- a/data/books/da.json
+++ b/data/books/da.json
@@ -68,14 +68,14 @@
     "1CH": [
         "1krøn",
 		"1_krøn",
-        "1krønikkebog",
-		"1_krønikkebog"
+        "1krønikebog",
+		"1_krønikebog"
     ],
     "2CH": [
         "2krøn",
 		"2_krøn",
-        "2krønikkebog",
-		"2_krønikkebog"
+        "2krønikebog",
+		"2_krønikebog"
     ],
     "EZR": [
         "ezra",


### PR DESCRIPTION
I accidentally made an extra k in Krønike.
It has been removed now 