### PR TITLE
feat: add Dutch book names

### DIFF
--- a/Languages.md
+++ b/Languages.md
@@ -5,6 +5,7 @@ Thanks to the community, we have support for the following languages:
 -   Brazilian Portuguese - [Brunofow](https://github.com/brunofow)
 -   Chinese - [John Huang](https://github.com/junwhuan)
 -   Danish - [Nicolai Skødt Holmgaard](https://github.com/Nicolai9852)
+-   Dutch - [Jaap Kramer](https://github.com/jaapkramer)
 -   English - [Jaanonim](https://github.com/jaanonim)
 -   German - [Tecur](https://github.com/Tecur)
 -   Norwegian - [Cmeeren](https://github.com/cmeeren)

--- a/data/books/nl.json
+++ b/data/books/nl.json
@@ -1,0 +1,297 @@
+{
+    "GEN": [
+        "genesis",
+        "gen"
+    ],
+    "EXO": [
+        "exodus",
+        "exod",
+        "exo",
+		"ex"
+    ],
+    "LEV": [
+        "leviticus",
+        "lev"
+    ],
+    "NUM": [
+        "numeri",
+        "num"
+    ],
+    "DEU": [
+        "deuteronomium",
+        "deut",
+        "deu"
+    ],
+    "JOS": [
+        "jozua",
+        "joz"
+    ],
+    "JDG": [
+        "richteren",
+        "richt",
+        "ri"
+    ],
+    "RUT": [
+        "ruth",
+        "rut"
+    ],
+    "1SA": [
+        "1samuel",
+        "1sam",
+        "1sa"
+    ],
+    "2SA": [
+        "2samuel",
+        "2sam",
+        "2sa"
+    ],
+    "1KI": [
+        "1koningen",
+        "1kon"
+    ],
+    "2KI": [
+        "2koningen",
+        "2kon"
+    ],
+    "1CH": [
+        "1kronieken",
+        "1kron",
+        "1kr"
+    ],
+    "2CH": [
+        "2kronieken",
+        "2kron",
+        "2kr"
+    ],
+    "EZR": [
+        "ezra",
+        "ezr"
+    ],
+    "NEH": [
+        "nehemia",
+        "neh"
+    ],
+    "EST": [
+        "esther",
+        "esth",
+        "est"
+    ],
+    "JOB": [
+        "job"
+    ],
+    "PSA": [
+        "psalm",
+        "psa",
+        "ps"
+    ],
+    "PRO": [
+        "spreuken",
+        "spr"
+    ],
+    "ECC": [
+        "prediker",
+        "pred",
+        "pr"
+    ],
+    "SNG": [
+        "hooglied",
+        "hoogl",
+        "hoog"
+    ],
+    "ISA": [
+        "jesaja",
+        "jes"
+    ],
+    "JER": [
+        "jeremia",
+        "jer"
+    ],
+    "LAM": [
+        "klaagliederen",
+        "klaag",
+		"klaagl"
+    ],
+    "EZK": [
+        "ezechiël",
+        "ezech",
+        "eze"
+    ],
+    "DAN": [
+        "daniel",
+        "dan"
+    ],
+    "HOS": [
+        "hosea",
+        "hos"
+    ],
+    "JOL": [
+        "joël",
+        "jol"
+    ],
+    "AMO": [
+        "amos",
+        "amo",
+		"am"
+    ],
+    "OBA": [
+        "obadja",
+        "obad",
+        "oba",
+		"ob"
+    ],
+    "JON": [
+        "jona",
+        "jon"
+    ],
+    "MIC": [
+        "micha",
+        "mic",
+		"mi"
+    ],
+    "NAM": [
+        "nahum",
+        "nah"
+    ],
+    "HAB": [
+        "habakuk",
+        "hab"
+    ],
+    "ZEP": [
+        "sefanja",
+        "sef",
+		"zef"
+    ],
+    "HAG": [
+        "haggai",
+        "hag"
+    ],
+    "ZEC": [
+        "zacharia",
+        "zach",
+        "zac"
+    ],
+    "MAL": [
+        "maleachi",
+        "mal"
+    ],
+    "MAT": [
+        "mattheüs",
+        "matt",
+        "mat"
+    ],
+    "MRK": [
+        "marcus",
+        "marc"
+    ],
+    "LUK": [
+        "lucas",
+        "luc"
+    ],
+    "JHN": [
+        "johannes",
+        "joh"
+    ],
+    "ACT": [
+        "handelingen",
+        "hand"
+    ],
+    "ROM": [
+        "romeinen",
+        "rom"
+    ],
+    "1CO": [
+        "1korinthiërs",
+        "1kor",
+        "1cor"
+    ],
+    "2CO": [
+        "2korinthiërs",
+        "2kor",
+        "2cor"
+    ],
+    "GAL": [
+        "galaten",
+        "gal"
+    ],
+    "EPH": [
+        "efeziërs",
+        "efz",
+        "ef"
+    ],
+    "PHP": [
+        "filippenzen",
+        "fil"
+    ],
+    "COL": [
+        "kolossenzen",
+        "kol",
+        "col"
+    ],
+    "1TH": [
+        "1tessalonicenzen",
+        "1tess",
+        "1tes"
+    ],
+    "2TH": [
+        "2tessalonicenzen",
+        "2tess",
+        "2tes"
+    ],
+    "1TI": [
+        "1timotheüs",
+        "1tim"
+    ],
+    "2TI": [
+        "2timotheüs",
+        "2tim"
+    ],
+    "TIT": [
+        "titus",
+        "tit"
+    ],
+    "PHM": [
+        "filemon",
+        "filem"
+    ],
+    "HEB": [
+        "hebreëen",
+        "hebr",
+		"heb"
+    ],
+    "JAS": [
+        "jakobus",
+        "jak",
+        "jac"
+    ],
+    "1PE": [
+        "1petrus",
+        "1petr",
+        "1pet"
+    ],
+    "2PE": [
+        "2petrus",
+        "2petr",
+        "2pet"
+    ],
+    "1JN": [
+        "1johannes",
+        "1joh"
+    ],
+    "2JN": [
+        "2johannes",
+        "2joh"
+    ],
+    "3JN": [
+        "3johannes",
+        "3joh"
+    ],
+    "JUD": [
+        "judas",
+        "jud"
+    ],
+    "REV": [
+        "openbaring",
+        "openb",
+        "op"
+    ]
+}

--- a/src/BooksLists.ts
+++ b/src/BooksLists.ts
@@ -6,6 +6,7 @@ import nob from "../data/books/nob.json";
 import pl from "../data/books/pl.json";
 import ptBr from "../data/books/pt-br.json";
 import de from "../data/books/de.json";
+import nl from "../data/books/nl.json";
 import zhCN from "../data/books/zh-CN.json";
 import zhHK from "../data/books/zh-HK.json";
 import es from "../data/books/es.json";
@@ -20,6 +21,7 @@ const booksNames = {
 	"Chinese Simplified": zhCN,
 	"Chinese Traditional": zhHK,
 	"Danish": da,
+	"Dutch": nl,
 	"English": en,
 	"German": de,
 	"Norwegian": nob,


### PR DESCRIPTION
This pull request adds support for the Dutch language to the project. The most important changes include adding Dutch language support to the list of languages, creating a JSON file with Dutch book names and abbreviations, and updating the import statements and book names list to include the new Dutch language data.

Additions for Dutch language support:

* [`Languages.md`](diffhunk://#diff-929ae722853617256445b7020dc5587f3fc4cfe86abcffb2d5b23820f863bdd0R8): Added Jaap Kramer as the contributor for Dutch language support.
* [`data/books/nl.json`](diffhunk://#diff-e6b74ce447f4a4440078c4c067651a1fbbd74109fe079aec6e18efb8e03159c6R1-R297): Created a new JSON file with Dutch book names and their abbreviations.

Code updates for Dutch language integration:

* [`src/BooksLists.ts`](diffhunk://#diff-216ffa9557e40cedd750b7401847f201a61676f5cf67221b97b69ab99acfa73aR9): Added import statement for the Dutch books JSON file.
* [`src/BooksLists.ts`](diffhunk://#diff-216ffa9557e40cedd750b7401847f201a61676f5cf67221b97b69ab99acfa73aR24): Updated the `booksNames` object to include Dutch language support.