### PR TITLE
fix: update Dutch book names for consistency and accuracy

### DIFF
--- a/data/books/nl.json
+++ b/data/books/nl.json
@@ -180,8 +180,8 @@
         "mat"
     ],
     "MRK": [
-        "marcus",
-        "marc"
+        "markus",
+        "mar"
     ],
     "LUK": [
         "lucas",
@@ -201,13 +201,11 @@
     ],
     "1CO": [
         "1korinthiërs",
-        "1kor",
-        "1cor"
+        "1kor"
     ],
     "2CO": [
         "2korinthiërs",
-        "2kor",
-        "2cor"
+        "2kor"
     ],
     "GAL": [
         "galaten",
@@ -216,7 +214,8 @@
     "EPH": [
         "efeziërs",
         "efz",
-        "ef"
+        "ef",
+        "efe"
     ],
     "PHP": [
         "filippenzen",
@@ -224,8 +223,7 @@
     ],
     "COL": [
         "kolossenzen",
-        "kol",
-        "col"
+        "kol"
     ],
     "1TH": [
         "1tessalonicenzen",
@@ -260,8 +258,7 @@
     ],
     "JAS": [
         "jakobus",
-        "jak",
-        "jac"
+        "jak"
     ],
     "1PE": [
         "1petrus",


### PR DESCRIPTION

This pull request updates the Dutch book name abbreviations in the `data/books/nl.json` file to better align with standard conventions and improve consistency. The primary changes involve refining abbreviations for several New Testament books.

**Abbreviation updates for New Testament books:**

* [`MRK`](diffhunk://#diff-e6b74ce447f4a4440078c4c067651a1fbbd74109fe079aec6e18efb8e03159c6L183-R184): Changed alternate names from `"marcus", "marc"` to `"markus", "mar"` for improved consistency.
* `1CO` and `2CO`: Removed `"1cor"` and `"2cor"`, keeping only `"1kor"` and `"2kor"` as abbreviations.
* [`EPH`](diffhunk://#diff-e6b74ce447f4a4440078c4c067651a1fbbd74109fe079aec6e18efb8e03159c6L219-R226): Added `"efe"` and kept `"ef"`, updating the list to `"efeziërs", "efz", "ef", "efe"`.
* [`COL`](diffhunk://#diff-e6b74ce447f4a4440078c4c067651a1fbbd74109fe079aec6e18efb8e03159c6L219-R226): Removed `"col"`, keeping only `"kol"` as the abbreviation.
* [`JAS`](diffhunk://#diff-e6b74ce447f4a4440078c4c067651a1fbbd74109fe079aec6e18efb8e03159c6L263-R261): Removed `"jac"`, keeping only `"jak"` as the abbreviation.