### PR TITLE
Chore: updated package-lock.json to reflect version 1.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "youversion-linker",
-	"version": "1.6.3",
+	"version": "1.6.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "youversion-linker",
-			"version": "1.6.3",
+			"version": "1.6.5",
 			"license": "MIT",
 			"dependencies": {
 				"tippy.js": "^6.3.7"


### PR DESCRIPTION
I believe this was missed the other day