### PR TITLE
Add route.bible as an alternative link destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Obsidian YouVersion Linker Plugin
 
-**Automatically link bible verses in your notes to [YouVersion bible](https://www.bible.com/).**
+**Automatically link bible verses in your notes to [YouVersion bible](https://www.bible.com/) or Route Bible.**
 
 **List of supported languages can be found [here](./Languages.md).**
 
@@ -15,7 +15,11 @@ You can for example type:
 It also supports multiple verses like: `John 3:16,18-20`.
 
 `@`, `>` and `^` chars are triggers for suggestion and they can be changed in settings.
-In settings you can select which version of bible you want to use and books names in which language will be detected.
+In settings you can select which version of bible you want to use, choose the `Link destination` (`YouVersion` or `Route Bible`), and pick which language of book names will be detected.
+
+Example setting:
+
+- `Link destination: Route Bible`
 
 I'm from Poland so plugin supports polish books names (eq. `J 1:1-6`, `Mt 24,1`). If you would like it to support your language books names read the guide in [Languages.md](./Languages.md).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Obsidian YouVersion Linker Plugin
 
-**Automatically link bible verses in your notes to [YouVersion bible](https://www.bible.com/) or Route Bible.**
+**Automatically link bible verses in your notes to [YouVersion bible](https://www.bible.com/) or route.bible.**
 
 **List of supported languages can be found [here](./Languages.md).**
 
@@ -15,11 +15,11 @@ You can for example type:
 It also supports multiple verses like: `John 3:16,18-20`.
 
 `@`, `>` and `^` chars are triggers for suggestion and they can be changed in settings.
-In settings you can select which version of bible you want to use, choose the `Link destination` (`YouVersion` or `Route Bible`), and pick which language of book names will be detected.
+In settings you can select which version of bible you want to use, choose the `Link destination` (`YouVersion` or `route.bible`), and pick which language of book names will be detected.
 
 Example setting:
 
-- `Link destination: Route Bible`
+- `Link destination: route.bible`
 
 I'm from Poland so plugin supports polish books names (eq. `J 1:1-6`, `Mt 24,1`). If you would like it to support your language books names read the guide in [Languages.md](./Languages.md).
 

--- a/src/EditorSuggester.ts
+++ b/src/EditorSuggester.ts
@@ -1,12 +1,6 @@
-import getBooks from "./books/Books";
-import {
-	bookRegex,
-	linkRegex,
-	chapterSeparatorRegex,
-	rangeSeparatorRegex,
-} from "./Regex";
+import { linkRegex } from "./Regex";
 import { ObsidianYouversionLinkerSettings } from "./settings/SettingsData";
-import Verse, { VerseElement } from "./verses/Verse";
+import Verse from "./verses/Verse";
 import VerseLink from "./verses/VerseLink";
 import ObsidianYouversionLinker from "./main";
 import {
@@ -19,9 +13,9 @@ import {
 } from "obsidian";
 import {
 	makeRegexTypeList,
-	makeVerseByType,
 	VerseType,
 } from "./verses/VerseType";
+import { getSuggestionsFromQuery } from "./Suggestions";
 
 export class EditorSuggester extends EditorSuggest<VerseLink> {
 	constructor(
@@ -123,63 +117,4 @@ export class EditorSuggester extends EditorSuggest<VerseLink> {
 			}
 		}
 	}
-}
-
-export function processVerses(verses_str: Array<string>): Array<VerseElement> {
-	return verses_str
-		.map((verse) => {
-			const [start, end] = verse
-				.split(rangeSeparatorRegex)
-				.map((v) => (v === undefined ? undefined : parseInt(v)));
-			return start === undefined
-				? undefined
-				: new VerseElement(start, end);
-		})
-		.filter((v) => v !== undefined) as Array<VerseElement>;
-}
-
-export function getSuggestionsFromQuery(
-	query: string,
-	verseType: VerseType,
-	settings: ObsidianYouversionLinkerSettings
-): Verse[] {
-	console.debug("get suggestion for query ", query.toLowerCase());
-
-	const book = query.match(bookRegex)?.first();
-	if (!book) {
-		console.error(`could not find through query`, query);
-		return [];
-	}
-
-	const booksUrl = getBooks(book, settings);
-	if (!booksUrl.length) {
-		console.error(`could not find book url`, book);
-		return [];
-	}
-
-	const numbersPartsOfQueryString = query.substring(book.length);
-	const [chapter_str, ...verses_str] = numbersPartsOfQueryString.split(
-		chapterSeparatorRegex
-	);
-	const verses = processVerses(verses_str);
-	const chapter = parseInt(chapter_str);
-
-	return booksUrl.flatMap(
-		(bookUrl) =>
-			settings.bibleVersions
-				.map((version) =>
-					makeVerseByType(
-						verseType,
-						{
-							version,
-							bookUrl,
-							book,
-							chapter,
-							verses,
-						},
-						settings
-					)
-				)
-				.filter((v) => v !== undefined) as Verse[]
-	);
 }

--- a/src/GenerateLinks.ts
+++ b/src/GenerateLinks.ts
@@ -1,6 +1,6 @@
 import { Editor, MarkdownView } from "obsidian";
 import { linkRegex } from "./Regex";
-import { getSuggestionsFromQuery } from "./EditorSuggester";
+import { getSuggestionsFromQuery } from "./Suggestions";
 import { ObsidianYouversionLinkerSettings } from "./settings/SettingsData";
 import Verse from "./verses/Verse";
 import { VerseType } from "./verses/VerseType";

--- a/src/Suggestions.ts
+++ b/src/Suggestions.ts
@@ -1,0 +1,68 @@
+import getBooks from "./books/Books";
+import {
+	bookRegex,
+	chapterSeparatorRegex,
+	rangeSeparatorRegex,
+} from "./Regex";
+import { ObsidianYouversionLinkerSettings } from "./settings/SettingsData";
+import Verse, { VerseElement } from "./verses/Verse";
+import { makeVerseByType, VerseType } from "./verses/VerseType";
+
+export function processVerses(verses_str: Array<string>): Array<VerseElement> {
+	return verses_str
+		.map((verse) => {
+			const [start, end] = verse
+				.split(rangeSeparatorRegex)
+				.map((v) => (v === undefined ? undefined : parseInt(v)));
+			return start === undefined
+				? undefined
+				: new VerseElement(start, end);
+		})
+		.filter((v) => v !== undefined) as Array<VerseElement>;
+}
+
+export function getSuggestionsFromQuery(
+	query: string,
+	verseType: VerseType,
+	settings: ObsidianYouversionLinkerSettings
+): Verse[] {
+	console.debug("get suggestion for query ", query.toLowerCase());
+
+	const book = query.match(bookRegex)?.[0];
+	if (!book) {
+		console.error(`could not find through query`, query);
+		return [];
+	}
+
+	const booksUrl = getBooks(book, settings);
+	if (!booksUrl.length) {
+		console.error(`could not find book url`, book);
+		return [];
+	}
+
+	const numbersPartsOfQueryString = query.substring(book.length);
+	const [chapter_str, ...verses_str] = numbersPartsOfQueryString.split(
+		chapterSeparatorRegex
+	);
+	const verses = processVerses(verses_str);
+	const chapter = parseInt(chapter_str);
+
+	return booksUrl.flatMap(
+		(bookUrl) =>
+			settings.bibleVersions
+				.map((version) =>
+					makeVerseByType(
+						verseType,
+						{
+							version,
+							bookUrl,
+							book,
+							chapter,
+							verses,
+						},
+						settings
+					)
+				)
+				.filter((v) => v !== undefined) as Verse[]
+	);
+}

--- a/src/settings/SettingTab.ts
+++ b/src/settings/SettingTab.ts
@@ -3,6 +3,7 @@ import { App, PluginSettingTab, Setting } from "obsidian";
 import VERSIONS from "../../data/versions.json";
 import booksNames from "../books/BooksLists";
 import { generateBooksList } from "../books/Books";
+import { LinkDestination } from "./SettingsData";
 
 export default class SettingTab extends PluginSettingTab {
 	plugin: ObsidianYouversionLinker;
@@ -18,10 +19,32 @@ export default class SettingTab extends PluginSettingTab {
 
 		this.bibleVersionSettings();
 
-		new Setting(containerEl)
-			.setName("Link trigger")
-			.setDesc(
-				"Trigger for autocomplete for linking verse in edit mode. Supports regex."
+			new Setting(containerEl)
+				.setName("Link destination")
+				.setDesc(
+					"Choose whether linked references open in YouVersion or Route Bible."
+				)
+				.addDropdown((dropdown) => {
+					dropdown.addOption(
+						LinkDestination.YOUVERSION,
+						"YouVersion"
+					);
+					dropdown.addOption(
+						LinkDestination.ROUTE_BIBLE,
+						"Route Bible"
+					);
+					dropdown.setValue(this.plugin.settings.linkDestination);
+					dropdown.onChange(async (value) => {
+						this.plugin.settings.linkDestination =
+							value as LinkDestination;
+						await this.plugin.saveSettings();
+					});
+				});
+
+			new Setting(containerEl)
+				.setName("Link trigger")
+				.setDesc(
+					"Trigger for autocomplete for linking verse in edit mode. Supports regex."
 			)
 			.addText((text) => {
 				text.setValue(this.plugin.settings.linkTrigger);

--- a/src/settings/SettingTab.ts
+++ b/src/settings/SettingTab.ts
@@ -22,7 +22,7 @@ export default class SettingTab extends PluginSettingTab {
 			new Setting(containerEl)
 				.setName("Link destination")
 				.setDesc(
-					"Choose whether linked references open in YouVersion or Route Bible."
+					"Choose whether linked references open in YouVersion or route.bible."
 				)
 				.addDropdown((dropdown) => {
 					dropdown.addOption(
@@ -31,7 +31,7 @@ export default class SettingTab extends PluginSettingTab {
 					);
 					dropdown.addOption(
 						LinkDestination.ROUTE_BIBLE,
-						"Route Bible"
+						"route.bible"
 					);
 					dropdown.setValue(this.plugin.settings.linkDestination);
 					dropdown.onChange(async (value) => {

--- a/src/settings/SettingsData.ts
+++ b/src/settings/SettingsData.ts
@@ -3,6 +3,11 @@ export interface BibleVersion {
 	language: string;
 }
 
+export enum LinkDestination {
+	YOUVERSION = "youversion",
+	ROUTE_BIBLE = "route-bible",
+}
+
 export interface ObsidianYouversionLinkerSettings {
 	bibleVersions: BibleVersion[];
 	linkPreviewRead: boolean;
@@ -12,6 +17,7 @@ export interface ObsidianYouversionLinkerSettings {
 	footnoteTrigger: string;
 	selectedBooksLanguages: string[];
 	calloutName: string;
+	linkDestination: LinkDestination;
 }
 
 export const DEFAULT_SETTINGS: ObsidianYouversionLinkerSettings = {
@@ -28,4 +34,5 @@ export const DEFAULT_SETTINGS: ObsidianYouversionLinkerSettings = {
 	footnoteTrigger: "(?<!\\[)\\^",
 	selectedBooksLanguages: ["English"],
 	calloutName: "Bible",
+	linkDestination: LinkDestination.YOUVERSION,
 };

--- a/src/verses/Verse.ts
+++ b/src/verses/Verse.ts
@@ -1,4 +1,4 @@
-import { BibleVersion } from "../settings/SettingsData";
+import { BibleVersion, LinkDestination } from "../settings/SettingsData";
 import VERSIONS from "../../data/versions.json";
 
 export class VerseElement {
@@ -22,7 +22,8 @@ export default abstract class Verse {
 		private bookUrl: string,
 		private book: string,
 		private chapter: number,
-		private verses: Array<VerseElement>
+		private verses: Array<VerseElement>,
+		private linkDestination: LinkDestination
 	) {}
 
 	public render(el: HTMLElement) {
@@ -51,12 +52,22 @@ export default abstract class Verse {
 		return "";
 	}
 
-	getUrl(): string {
+	getPreviewUrl(): string {
 		const base = "https://www.bible.com/bible";
 		let url = `${base}/${this.version.id}/${this.bookUrl}.${this.chapter}`;
 		if (this.verses.length > 0) {
 			url += `.${this.verses.map((verse) => verse.toString()).join(",")}`;
 		}
 		return url;
+	}
+
+	getDestinationUrl(): string {
+		if (this.linkDestination === LinkDestination.ROUTE_BIBLE) {
+			return `https://route.bible/?q=${encodeURIComponent(
+				this.toSimpleText()
+			)}&utm_source=obsidian_youversion_linker&utm_medium=link`;
+		}
+
+		return this.getPreviewUrl();
 	}
 }

--- a/src/verses/VerseEmbed.ts
+++ b/src/verses/VerseEmbed.ts
@@ -1,6 +1,6 @@
-import { escapeMarkdown } from "src/utils/Markdown";
+import { escapeMarkdown } from "../utils/Markdown";
 import LinkPreviewManager from "../preview/LinkPreview";
-import { BibleVersion } from "../settings/SettingsData";
+import { BibleVersion, LinkDestination } from "../settings/SettingsData";
 import Verse, { VerseElement } from "./Verse";
 
 export default class VerseEmbed extends Verse {
@@ -10,20 +10,21 @@ export default class VerseEmbed extends Verse {
 		book: string,
 		chapter: number,
 		verses: Array<VerseElement>,
+		linkDestination: LinkDestination,
 		private insertNewLine: boolean,
 		private calloutName: string
 	) {
-		super(version, bookUrl, book, chapter, verses);
+		super(version, bookUrl, book, chapter, verses, linkDestination);
 	}
 
 	async toReplace(): Promise<string> {
-		const content = await LinkPreviewManager.processUrl(this.getUrl());
+		const content = await LinkPreviewManager.processUrl(this.getPreviewUrl());
 		const p = this.insertNewLine ? "\n" : "";
 		if (content.err) {
 			return `${p}>[!Error] Cannot get content of ${this.toSimpleText()}.\n`;
 		} else {
 			// prettier-ignore
-			return `${p}>[!${this.calloutName}] [${this.toSimpleText()} ${content.info.version}](${this.getUrl()})\n>${escapeMarkdown(content.verses).replace(/\n/g,'\n>')}\n`;
+			return `${p}>[!${this.calloutName}] [${this.toSimpleText()} ${content.info.version}](${this.getDestinationUrl()})\n>${escapeMarkdown(content.verses).replace(/\n/g,'\n>')}\n`;
 		}
 	}
 }

--- a/src/verses/VerseFootnote.ts
+++ b/src/verses/VerseFootnote.ts
@@ -1,23 +1,23 @@
-import { escapeMarkdown } from "src/utils/Markdown";
+import { escapeMarkdown } from "../utils/Markdown";
 import LinkPreviewManager from "../preview/LinkPreview";
 import Verse from "./Verse";
 
 export default class VerseFootnote extends Verse {
 	async toReplace(): Promise<string> {
-		const content = await LinkPreviewManager.processUrl(this.getUrl());
+		const content = await LinkPreviewManager.processUrl(this.getPreviewUrl());
 		const linkText = this.toSimpleText();
 		return `[^${linkText.replace(/\s/g, "")}${content.info.version}]`;
 	}
 
 	async endInsert(): Promise<string> {
-		const content = await LinkPreviewManager.processUrl(this.getUrl());
+		const content = await LinkPreviewManager.processUrl(this.getPreviewUrl());
 		const linkText = this.toSimpleText();
 		if (content.err) {
 			// prettier-ignore
-			return `\n[^${linkText.replace(/\s/g,"")}${content.info.version}]: [${linkText} ${content.info.version}](${this.getUrl()})`;
+			return `\n[^${linkText.replace(/\s/g,"")}${content.info.version}]: [${linkText} ${content.info.version}](${this.getDestinationUrl()})`;
 		} else {
 			// prettier-ignore
-			return `\n[^${linkText.replace(/\s/g,"")}${content.info.version}]: [${linkText} ${content.info.version}](${this.getUrl()}) ${escapeMarkdown(content.verses.replace(/\n/g,' '))}`;
+			return `\n[^${linkText.replace(/\s/g,"")}${content.info.version}]: [${linkText} ${content.info.version}](${this.getDestinationUrl()}) ${escapeMarkdown(content.verses.replace(/\n/g,' '))}`;
 		}
 	}
 }

--- a/src/verses/VerseLink.ts
+++ b/src/verses/VerseLink.ts
@@ -2,6 +2,6 @@ import Verse from "./Verse";
 
 export default class VerseLink extends Verse {
 	async toReplace(): Promise<string> {
-		return `[${this.toSimpleText()}](${this.getUrl()})`;
+		return `[${this.toSimpleText()}](${this.getDestinationUrl()})`;
 	}
 }

--- a/src/verses/VerseType.ts
+++ b/src/verses/VerseType.ts
@@ -1,7 +1,7 @@
 import {
 	BibleVersion,
 	ObsidianYouversionLinkerSettings,
-} from "src/settings/SettingsData";
+} from "../settings/SettingsData";
 import { VerseElement } from "./Verse";
 import VerseEmbed from "./VerseEmbed";
 import VerseLink from "./VerseLink";
@@ -47,40 +47,44 @@ export function makeVerseByType(
 ) {
 	switch (verseType) {
 		case VerseType.EMBED:
-			return new VerseEmbed(
+				return new VerseEmbed(
+					data.version,
+					data.bookUrl,
+					data.book,
+					data.chapter,
+					data.verses,
+					settings.linkDestination,
+					false,
+					settings.calloutName
+				);
+			case VerseType.EMBED_NL:
+				return new VerseEmbed(
+					data.version,
+					data.bookUrl,
+					data.book,
+					data.chapter,
+					data.verses,
+					settings.linkDestination,
+					true,
+					settings.calloutName
+				);
+			case VerseType.LINK:
+				return new VerseLink(
 				data.version,
-				data.bookUrl,
-				data.book,
-				data.chapter,
-				data.verses,
-				false,
-				settings.calloutName
-			);
-		case VerseType.EMBED_NL:
-			return new VerseEmbed(
-				data.version,
-				data.bookUrl,
-				data.book,
-				data.chapter,
-				data.verses,
-				true,
-				settings.calloutName
-			);
-		case VerseType.LINK:
-			return new VerseLink(
-				data.version,
-				data.bookUrl,
-				data.book,
-				data.chapter,
-				data.verses
-			);
-		case VerseType.FOOTNOTE:
-			return new VerseFootnote(
-				data.version,
-				data.bookUrl,
-				data.book,
-				data.chapter,
-				data.verses
-			);
+					data.bookUrl,
+					data.book,
+					data.chapter,
+					data.verses,
+					settings.linkDestination
+				);
+			case VerseType.FOOTNOTE:
+				return new VerseFootnote(
+					data.version,
+					data.bookUrl,
+					data.book,
+					data.chapter,
+					data.verses,
+					settings.linkDestination
+				);
+		}
 	}
-}

--- a/test/link-destination.test.ts
+++ b/test/link-destination.test.ts
@@ -34,7 +34,7 @@ describe("Link destination", () => {
 		jest.clearAllMocks();
 	});
 
-	test("builds a Route Bible URL for a matched reference", async () => {
+	test("builds a route.bible URL for a matched reference", async () => {
 		const [suggestion] = getSuggestionsFromQuery(
 			"John 3:16",
 			VerseType.LINK,

--- a/test/link-destination.test.ts
+++ b/test/link-destination.test.ts
@@ -1,0 +1,84 @@
+import LinkPreviewManager from "../src/preview/LinkPreview";
+import { getSuggestionsFromQuery } from "../src/Suggestions";
+import {
+	DEFAULT_SETTINGS,
+	LinkDestination,
+	ObsidianYouversionLinkerSettings,
+} from "../src/settings/SettingsData";
+import { VerseType } from "../src/verses/VerseType";
+
+jest.mock("../src/preview/LinkPreview", () => ({
+	__esModule: true,
+	default: {
+		processUrl: jest.fn(),
+	},
+}));
+
+const mockedLinkPreviewManager = LinkPreviewManager as jest.Mocked<
+	typeof LinkPreviewManager
+>;
+
+function getSettings(
+	linkDestination: LinkDestination
+): ObsidianYouversionLinkerSettings {
+	return {
+		...DEFAULT_SETTINGS,
+		linkDestination,
+		bibleVersions: [{ id: "1", language: "eng" }],
+		selectedBooksLanguages: ["English"],
+	};
+}
+
+describe("Link destination", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test("builds a Route Bible URL for a matched reference", async () => {
+		const [suggestion] = getSuggestionsFromQuery(
+			"John 3:16",
+			VerseType.LINK,
+			getSettings(LinkDestination.ROUTE_BIBLE)
+		);
+
+		expect(await suggestion.toReplace()).toBe(
+			"[John 3:16](https://route.bible/?q=John%203%3A16&utm_source=obsidian_youversion_linker&utm_medium=link)"
+		);
+	});
+
+	test("keeps the existing YouVersion URL by default", async () => {
+		const [suggestion] = getSuggestionsFromQuery(
+			"Romans 8:28-29",
+			VerseType.LINK,
+			getSettings(LinkDestination.YOUVERSION)
+		);
+
+		expect(await suggestion.toReplace()).toBe(
+			"[Romans 8:28-29](https://www.bible.com/bible/1/ROM.8.28-29)"
+		);
+	});
+
+	test("keeps quote generation unchanged apart from the destination link", async () => {
+		mockedLinkPreviewManager.processUrl.mockResolvedValue({
+			err: false,
+			info: { title: "John 3:16", version: "KJV" },
+			verses: "For God so loved the world",
+		});
+
+		const [suggestion] = getSuggestionsFromQuery(
+			"John 3:16",
+			VerseType.EMBED,
+			getSettings(LinkDestination.ROUTE_BIBLE)
+		);
+
+		const result = await suggestion.toReplace();
+
+		expect(mockedLinkPreviewManager.processUrl).toHaveBeenCalledWith(
+			"https://www.bible.com/bible/1/JHN.3.16"
+		);
+		expect(result).toContain(
+			"(https://route.bible/?q=John%203%3A16&utm_source=obsidian_youversion_linker&utm_medium=link)"
+		);
+		expect(result).toContain(">For God so loved the world");
+	});
+});


### PR DESCRIPTION
## Summary
- adds `Link destination` with `YouVersion` as the default and `route.bible` as an alternative
- keeps the existing parsing, triggers, language detection, quote flow, and footnote flow intact
- makes the route.bible destination opt-in and non-breaking

## Implementation
- adds a persisted `linkDestination` setting
- routes outbound reference links to route.bible when selected
- keeps YouVersion preview fetching for quote and footnote generation so current content behavior stays unchanged
- adds focused tests for route.bible URL generation, existing YouVersion URL generation, and quote regression coverage
- adds a short README settings example

## Validation
- `npm test -- --runInBand`
- `npm run build`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required because this change only normalizes user-visible route.bible branding copy in docs, settings text, and test descriptions.
